### PR TITLE
Fixes #3399 - Remove versionning of the scala-ldap in the pom.xml of scala-ldap repository which is became useless since all versions are identical for each rudder part and in the parent-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@ limitations under the License.
   </parent>
   
   <artifactId>scala-ldap</artifactId>
-  <version>2.5.2-SNAPSHOT</version>
 
   <description>
     This project define a Scala API to interoperate with LDAP


### PR DESCRIPTION
Fixes #3399 - Remove versionning of the scala-ldap in the pom.xml of scala-ldap repository which is became useless since all versions are identical for each rudder part and in the parent-pom
