### PR TITLE
Fix Windows file separator bug

### DIFF
--- a/src/main/scala/com/normation/ldap/ldif/LDIFFileLogger.scala
+++ b/src/main/scala/com/normation/ldap/ldif/LDIFFileLogger.scala
@@ -111,7 +111,7 @@ trait Slf4jLDIFLogger extends LDIFFileLogger {
   }
 
   protected def traceFileName(dn:DN, opType:String) : String = {
-    val fileName = dn.getRDNStrings().map( _.replaceAll(File.separator, "|")).reverse.mkString("/")
+    val fileName = dn.getRDNStrings().map( _.replaceAll("\\" + File.separator, "|")).reverse.mkString("/")
     fileName + "-" + System.currentTimeMillis.toString + "-" + opType + ".ldif"
   }
 


### PR DESCRIPTION
The following bit of code:
```scala
protected def traceFileName(dn:DN, opType:String) : String = {
    val fileName = dn.getRDNStrings().map( _.replaceAll(File.separator, "|")).reverse.mkString("/")
    fileName + "-" + System.currentTimeMillis.toString + "-" + opType + ".ldif"
  }
```

Appears to result in an error on Windows. Specifically, the problem is the following:

```scala
scala> "c\\programs\\ldap".replaceAll("\\", "x")
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
 ^
  at java.util.regex.Pattern.error(Pattern.java:1924)
  at java.util.regex.Pattern.compile(Pattern.java:1671)
  at java.util.regex.Pattern.<init>(Pattern.java:1337)
  at java.util.regex.Pattern.compile(Pattern.java:1022)
  at java.lang.String.replaceAll(String.java:2162)
  ... 33 elided
```

The first parameter of replaceAll is meant to be a Regex string. In Regex, a simple backslash must be double-escaped ("\\\\\\\\"); a simply-escaped backslash is a read as an escape character in Regex.

The following is a fix:

```scala
protected def traceFileName(dn:DN, opType:String) : String = {
    val fileName = dn.getRDNStrings().map( _.replaceAll("\\" + File.separator, "|")).reverse.mkString("/")
    fileName + "-" + System.currentTimeMillis.toString + "-" + opType + ".ldif"
  }
```

It works on Linux as well, as an escaped forward slash is simply a forward slash:

```scala
scala> "c/programs/ldap".replaceAll("\\/", "x")
res2: String = cxprogramsxldap
```